### PR TITLE
Check if shape exists prior to adding

### DIFF
--- a/src/components/GradientForm.vue
+++ b/src/components/GradientForm.vue
@@ -56,11 +56,13 @@ export default {
   },
   methods: {
     addShape() {
-      this.$store.commit('addShape', {
-        id: this.id,
-        string: this.previewGradient
-      })
-      this.id++
+      if (this.previewGradient) {
+        this.$store.commit('addShape', {
+          id: this.id,
+          string: this.previewGradient
+        })
+        this.id++
+      }
     },
     ...mapMutations(['undoShape', 'deleteShapes'])
   }


### PR DESCRIPTION
Hello hello! Great project 😺

If you 'Delete all shapes' and then immediately 'Add' a new shape, the newly added shape will be empty. This PR checks to make sure that the preview gradient exists prior to adding.