### PR TITLE
Add export to codepen button

### DIFF
--- a/src/components/GradientList.vue
+++ b/src/components/GradientList.vue
@@ -74,7 +74,7 @@ export default {
     ...mapGetters(['gradientList', 'previewGradient', 'gradientStrings']),
     getFormData() {
       return JSON.stringify({
-        title: 'New Pen!',
+        title: 'Shapy Gradient 🤖',
         html: '<div class="gradient"></div>',
         css: `.gradient {
   height: 500px;

--- a/src/components/GradientList.vue
+++ b/src/components/GradientList.vue
@@ -66,19 +66,27 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import { createHelpers } from 'vuex-map-fields'
+const { mapFields } = createHelpers({
+  getterType: 'canvas/getField'
+})
+
 export default {
   data: () => ({
     copied: false
   }),
   computed: {
+    ...mapFields(['canvas']),
     ...mapGetters(['gradientList', 'previewGradient', 'gradientStrings']),
     getFormData() {
       return JSON.stringify({
         title: 'Shapy Gradient 🤖',
         html: '<div class="gradient"></div>',
-        css: `.gradient {
-  height: 500px;
-  width: 500px;
+        css: `
+body, html {width: 100%; height: 100%}
+.gradient {
+  height: ${this.canvas.x.size}${this.canvas.x.unit};
+  width: ${this.canvas.y.size}${this.canvas.y.unit};
   background: ${this.gradientStrings};
 }`
       })

--- a/src/components/GradientList.vue
+++ b/src/components/GradientList.vue
@@ -2,9 +2,8 @@
   <ul class="gradient-list">
     <li class="preview-string">
       <span class="string-label">Preview:</span>
-      <span v-highlightjs="previewGradient"><code class="css"/></span>
-      <span
-        class="string-label">Added:</span>
+      <span v-highlightjs="previewGradient"><code class="css" /></span>
+      <span class="string-label">Added:</span>
     </li>
     <li
       class="no-items"
@@ -16,7 +15,7 @@
       <div
         class="gradient-code"
         v-highlightjs="gradient.string">
-        <code class="css"/>
+        <code class="css" />
       </div>
       <div class="gradient-details">
         <button
@@ -45,6 +44,22 @@
             :key="'copied'">Copied!</div>
         </transition>
       </button>
+      <form
+        class="export-form"
+        action="https://codepen.io/pen/define"
+        method="POST"
+        target="_blank">
+        <input
+          type="hidden"
+          name="data"
+          :value="getFormData">
+        <button
+          type="submit"
+          class="btn btn-export btn-shadow">
+          Export to CodePen
+        </button>
+      </form>
+
     </li>
   </ul>
 </template>
@@ -56,7 +71,18 @@ export default {
     copied: false
   }),
   computed: {
-    ...mapGetters(['gradientList', 'previewGradient', 'gradientStrings'])
+    ...mapGetters(['gradientList', 'previewGradient', 'gradientStrings']),
+    getFormData() {
+      return JSON.stringify({
+        title: 'New Pen!',
+        html: '<div class="gradient"></div>',
+        css: `.gradient {
+  height: 500px;
+  width: 500px;
+  background: ${this.gradientStrings};
+}`
+      })
+    }
   },
   methods: {
     deleteGradient(id) {
@@ -86,6 +112,9 @@ export default {
 
     li
       line-height: 1.3
+
+  .export-form
+    display: inline
 
   .no-items
     color: $white
@@ -133,10 +162,15 @@ export default {
     opacity: .7
     margin-right: 1em
 
-  .copy
+  .copy, .export
     position: absolute
     bottom: 0
     right: 1rem
+
+  .btn-export
+    background: $red
+    min-width: 130px
+
 
   .btn-copy
     background: $green


### PR DESCRIPTION
<!--- For more information, please see our contribution guidelines -->

<!-- Thank you for submitting a pull request! Please provide us with enough details to make it easier for others to review your pull request -->

## Type of Change

<!-- Please check the boxes that apply -->

- [ ] Bugfix (a fix that does not break existing functionality)
- [x] Enhancement (new feature/minor improvement)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)

## What is Changed

Adds a button that exports the current gradient into a pen

## Comments

closes #20
<img width="1491" alt="screenshot 2018-12-06 at 18 25 08" src="https://user-images.githubusercontent.com/1051509/49600832-747abc00-f984-11e8-9bf2-db6302de4171.png">


## Checklist

- [x] I have read the **CONTRIBUTING** guideline.
- [x] I have given this pull request a clear and descriptive title
- [x] I have clearly described the changes that this pull request makes
- [x] I have included relevant information or comments