### PR TITLE
feat: disable copy css button

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -54,4 +54,8 @@ a:visited
 
 a:hover
   color: $green
+
+button:disabled
+  pointer-events: none
+  opacity: 0.3
 </style>

--- a/src/components/GradientForm.vue
+++ b/src/components/GradientForm.vue
@@ -18,6 +18,7 @@
           v-clipboard:copy="gradientStrings"
           v-clipboard:success="copyCode"
           :key="'copy'"
+          :disabled="!gradientStrings"
           class="btn btn-copy btn-shadow"
         >
           <transition name="copy" mode="out-in">


### PR DESCRIPTION
## Type of Change

<!-- Please check the boxes that apply -->

- [ ] Bugfix (a fix that does not break existing functionality)
- [x] Enhancement (new feature/minor improvement)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)

## What is Changed

- Added `disabled` to **Copy CSS** button when there are no added gradients.
- Added global styles for disabled buttons

## Comments

![TxR8wthcB7](https://user-images.githubusercontent.com/5058640/56393486-e3222d00-6234-11e9-863d-15fe24eab945.gif)

<!-- Please include any comments that you might have -->

## Checklist

- [x] I have read the **CONTRIBUTING** guideline.
- [x] I have given this pull request a clear and descriptive title
- [x] I have clearly described the changes that this pull request makes
- [x] I have included relevant information or comments