### PR TITLE
feat: add reverse colors button

### DIFF
--- a/src/components/fieldsets/FieldsetColors.vue
+++ b/src/components/fieldsets/FieldsetColors.vue
@@ -45,6 +45,14 @@
               />
               <div class="hover">Add</div>
             </button>
+            <button class="icon-btn icon-reverse" @click="reverseColors(stop)">
+              <font-awesome-icon
+                :icon="['fas', 'sync-alt']"
+                aria-hidden="true"
+                class="btn-icon"
+              />
+              <div class="hover">Reverse</div>
+            </button>
             <button class="icon-btn icon-remove" @click="removeStop(stop.id)">
               <font-awesome-icon
                 :icon="['fas', 'minus-circle']"
@@ -143,6 +151,15 @@ export default {
       setTimeout(() => {
         this.removeError = false
       }, 3000)
+    },
+    reverseColors(stop) {
+      if (stop) {
+        const currentStart = stop.start.color
+        const currentStop = stop.stop.color
+
+        stop.stop.color = currentStart
+        stop.start.color = currentStop
+      }
     }
   }
 }
@@ -199,11 +216,23 @@ export default {
   right: -65px
   transform: translateX(-5px)
 
+.icon-reverse .hover
+  right: -22px
+  bottom: -22px
+  transform: translateY(-5px)
+
 .btn-icon
   font-size: 1.1em
 
 .icon-remove
   color: $black
+
+.icon-reverse
+  color: $black
+  &:hover
+    & > svg
+      transition: transform .5s ease-out
+      transform: rotate(180deg)
 
 .icon-add
   color: $green
@@ -224,7 +253,7 @@ export default {
 .remove-error
   font-size: .8em
   animation: error .3s ease-in-out 1
-  margin-top: .5em
+  margin-top: 1.5em
 
 @keyframes error
   0%,100%

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,8 @@ import {
   faMinusCircle,
   faTrashAlt,
   faPencilAlt,
-  faCopy
+  faCopy,
+  faSyncAlt
 } from '@fortawesome/free-solid-svg-icons'
 import {
   faTwitter,
@@ -31,7 +32,8 @@ library.add(
   faTrashAlt,
   faPencilAlt,
   faCodepen,
-  faCopy
+  faCopy,
+  faSyncAlt
 )
 
 Vue.component('font-awesome-icon', FontAwesomeIcon)


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix (a fix that does not break existing functionality)
- [x] Enhancement (new feature/minor improvement)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)

## What is Changed

- Added a reverse button that reverses the colors of each stop according to #28
- Added sync font icon for the button
- Added css for the button
- Added a `reverseColors` method

## Comments

![udTEujxfs7](https://user-images.githubusercontent.com/5058640/56447975-d58ba680-630b-11e9-9982-0cc541fa0758.gif)

## Checklist

- [x] I have read the **CONTRIBUTING** guideline.
- [x] I have given this pull request a clear and descriptive title
- [x] I have clearly described the changes that this pull request makes
- [x] I have included relevant information or comments